### PR TITLE
Reduce crawler aggressiveness and add adaptive throttling

### DIFF
--- a/negative_keys.txt
+++ b/negative_keys.txt
@@ -1,0 +1,9 @@
+contact
+support
+поиск
+search
+subscribe
+newsletter
+login
+signin
+checkout

--- a/positive_keys.txt
+++ b/positive_keys.txt
@@ -1,0 +1,7 @@
+comment
+content
+text
+body
+message
+post
+reply

--- a/user_agents.txt
+++ b/user_agents.txt
@@ -1,0 +1,6 @@
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0
+Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36 Edg/119.0.0.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36
+Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36


### PR DESCRIPTION
## Summary
- soften default crawl parameters and add per-host rate limiting
- stabilize sessions with fixed user agents and gzip-enabled realistic headers
- handle anti-bot responses with cool-down retries and export UA/keyword lists

## Testing
- `go build ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f44ace7cc832e823c5ba1485853a2